### PR TITLE
Slackへ通知するメッセージを動的に変更

### DIFF
--- a/routes/router.ts
+++ b/routes/router.ts
@@ -83,7 +83,7 @@ router.get('/contact/success', async (req, res) => {
     // コンタクトデータ取得
     const id = req.query.id
 
-    if (!id || isNaN(Number(id))) {
+    if (!id) {
       throw new Error('無効なコンタクトIDです。')
     }
 


### PR DESCRIPTION
## 概要
・Slackへ通知するメッセージを動的に変更

※想定した処理フロー
`/contact/create`にて問合せ内容をDBに登録後、`/contact/success`へリダイレクトさせ、今回追記した処理を走らせる。

## 変更する理由
静的な通知メッセージは本番環境で使えないため。

## 機能実行結果のスクショ
・ブラウザ
![Screen Shot 2023-07-22 at 12 29 27](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/d1fc3414-df4b-4d6b-9497-c603d2b040a5)
・Slack
![Screen Shot 2023-07-22 at 12 21 04](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/8840c623-0692-4821-939c-0c2d7b4a2cb6)