### PR TITLE
/contactで画面が表示できるように修正

### DIFF
--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { useState } from 'react'
+import { Box, Button, Stack, Text } from '@chakra-ui/react'
+import { ContactList } from '../../components/organisms/ContactList'
+import React from 'react'
+
+export default function Page() {
+  const [fontSize, setFontSize] = useState(16)
+
+  const increase = () => {
+    setFontSize((prev) => Math.min(50, prev + 2))
+  }
+
+  const decrease = () => {
+    setFontSize((prev) => Math.max(10, prev - 2))
+  }
+
+  return (
+    <>
+      <h1>お問い合わせ一覧</h1>
+      <Box>
+        <Stack direction="row" spacing={4}>
+          <Button bg="teal.300" color="white" onClick={increase}>
+            拡大
+          </Button>
+          <Button bg="red.300" color="white" onClick={decrease}>
+            縮小
+          </Button>
+        </Stack>
+        <Text fontSize={fontSize + 'px'}>
+          上のボタンを押すと、このテキストのサイズが変わります(最小サイズ：10px・最大サイズ：50px)。
+        </Text>
+
+        <ContactList />
+      </Box>
+    </>
+  )
+}

--- a/frontend/components/organisms/ContactList.tsx
+++ b/frontend/components/organisms/ContactList.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { useEffect } from 'react'
+import useSWR from 'swr'
+
+export function ContactList() {
+  const fetcher = async () =>
+    (await fetch('http://localhost:8000/admin/contacts')).json()
+
+  const { data, error } = useSWR('contactList', fetcher)
+
+  if (error) return <div>failed to load</div>
+  if (!data) return <div>loading...</div>
+
+  return (
+    <div>
+      <p>お問い合わせ一覧</p>
+      {data &&
+        data.map((d) => {
+          return (
+            <div>
+              <p>{d.id}</p>
+              <p>{d.name}</p>
+              <p>{d.email}</p>
+              <p>{d.subject}</p>
+              <p>{d.message}</p>
+            </div>
+          )
+        })}
+    </div>
+  )
+}


### PR DESCRIPTION

## 概要

http://localhost:3000/contact
でお問い合わせ一覧画面が表示されるように実装

## 変更する理由

## UI変更前後のスクショ・機能実行結果のスクショ
<!-- 
|  変更前のスクショ  |  変更後のスクショ  |
| ---- | ---- |
|  TD  |  TD  |
|  TD  |  TD  |
-->

![スクリーンショット 2023-08-04 0 23 48](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/51443889/1f274055-e9b0-4d95-a07a-4423f02d949d)


## コメント
