### PR TITLE
Videoテーブルにsection_idとorder追加

### DIFF
--- a/backend/prisma/migrations/20230815133145_init/migration.sql
+++ b/backend/prisma/migrations/20230815133145_init/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - Added the required column `order` to the `Video` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `section_id` to the `Video` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `Video` ADD COLUMN `order` INTEGER NOT NULL,
+    ADD COLUMN `section_id` INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE `Video` ADD CONSTRAINT `Video_section_id_fkey` FOREIGN KEY (`section_id`) REFERENCES `Section`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Section {
   id         Int      @id @default(autoincrement())
   course     Course    @relation(fields: [course_id], references: [id])
   course_id  Int
+  videos     Video []
   title      String
   order      Int
   published  Boolean   @default(false) // セクションが公開されているかどうか。
@@ -35,6 +36,9 @@ model Section {
 
 model Video {
   id          Int       @id @default(autoincrement())
+  section     Section    @relation(fields: [section_id], references: [id])
+  section_id  Int
+  order       Int
   name        String
   description String
   url         String


### PR DESCRIPTION
## 概要
ビデオテーブルにセクションIDとorderを追加
## 変更する理由
セクションごとにビデオを管理するため
## UI変更前後のスクショ・機能実行結果のスクショ

<img width="1440" alt="スクリーンショット 2023-08-15 22 32 21" src="https://github.com/ishida-frontend/engineer-tenshoku-master/assets/61638997/0420858d-fd03-46ba-b7a1-9a97cd434a80">
