### PR TITLE
埋め込み動画用URLへの変換ロジックの実装

### DIFF
--- a/backend/scripts/createVideo.ts
+++ b/backend/scripts/createVideo.ts
@@ -1,16 +1,18 @@
 import { PrismaClient } from '@prisma/client'
 
+import { convertVideoUrl } from '../utils/convertVideoUrl'
 import { VideoType } from '../types'
 
 const prisma = new PrismaClient()
 
 export async function createVideo(videoData: VideoType) {
   try {
+    const videoUrl = convertVideoUrl(videoData.url)
     await prisma.video.create({
       data: {
         name: videoData.name,
         description: videoData.description,
-        url: videoData.url,
+        url: videoUrl,
         order: videoData.order,
         published: videoData.published,
         section: { connect: { id: videoData.sectionId } },

--- a/backend/scripts/updateVideo.ts
+++ b/backend/scripts/updateVideo.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client'
 
+import { convertVideoUrl } from '../utils/convertVideoUrl'
 import { VideoType } from '../types'
 
 const prisma = new PrismaClient()
@@ -13,6 +14,8 @@ export async function updateVideo({
   published,
 }: Partial<VideoType>) {
   try {
+    const videoUrl = convertVideoUrl(url)
+
     const currentVideo = await prisma.video.findUnique({
       where: { id },
       select: { order: true },
@@ -60,7 +63,7 @@ export async function updateVideo({
         name,
         description,
         order: newOrder !== undefined ? newOrder : currentOrder,
-        url,
+        url: videoUrl,
         published,
       },
     })

--- a/backend/utils/convertVideoUrl.ts
+++ b/backend/utils/convertVideoUrl.ts
@@ -1,0 +1,29 @@
+export const convertVideoUrl = (videoUrl?: string): string | null => {
+  if (!videoUrl) {
+    throw new Error('有効な動画URLではありません')
+  }
+
+  // 通常の YouTube URL (ブラウザのアドレスバーに表示されるURL) ＆　再生リストに入った動画のURL
+  let regExp = /https:\/\/www\.youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)/
+  let match = videoUrl.match(regExp)
+  if (match && match[1]) {
+    return `https://www.youtube.com/embed/${match[1]}`
+  }
+
+  // 短縮された YouTube URl (YouTube動画画面の「共有」から取得できるURL)
+  regExp = /https:\/\/youtu\.be\/([a-zA-Z0-9_-]+)/
+  match = videoUrl.match(regExp)
+  if (match && match[1]) {
+    return `https://www.youtube.com/embed/${match[1]}`
+  }
+
+  // Vimeo URL (ブラウザのアドレスバーに表示されるURL)
+  regExp = /https:\/\/vimeo\.com\/(\d+)/
+  match = videoUrl.match(regExp)
+  if (match && match[1]) {
+    return `https://player.vimeo.com/video/${match[1]}`
+  }
+
+  // どの種類のURLにも該当しない場合は、そのまま返す
+  return videoUrl
+}


### PR DESCRIPTION
## 概要
・動画管理画面で登録・編集する動画URLを埋め込み用URLへ変換するロジック

## 実装する理由・変更する理由
・埋め込み用URLを手動で用意する手間を省くため

## UI変更前後のスクショ・機能実行結果のスクショ
**動画登録時の動作確認動画（YouTubeのURLを変換）**

https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/84de6fad-d47e-4e38-86f9-b27a3d3c7936



**動画編集時の動作確認動画（VimeoのURLを変換）**



https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/791b3da0-088d-40bf-9d1e-818706161f46


## コメント
URL変換関数（`backend/utils/convertVideoUrl.ts`）を以下のファイルにインポートして使用しています。
- `backend/scripts/createVideo.ts`
- `backend/scripts/updateVideo.ts`


この関数は、以下の種類のURLが引数で渡された際に、それを埋め込み用URLへ変換します。
**YouTubeのURL**
1. 通常の YouTube URL (ブラウザのアドレスバーに表示されるURL) 
例：https://www.youtube.com/watch?v=saZWk30sT64

2. 再生リストに入ったYouTubeのURL
例：https://www.youtube.com/watch?v=saZWk30sT64&list=PLaL5xqgewzqp0yhW85zUcO2HafKjVSHAO&index=1

3. 短縮された YouTube URl (YouTube動画画面の「共有」から取得できるURL)
例：https://youtu.be/saZWk30sT64?si=KXju5slYyAOKDidC

上記３つの変換後のURL：https://www.youtube.com/embed/saZWk30sT64

**VimeoのURL**
例：https://vimeo.com/524933864

変換後のURL：https://player.vimeo.com/video/524933864
