### PR TITLE
埋め込み動画用URLへの変換ロジックの修正

### DIFF
--- a/backend/scripts/updateVideo.ts
+++ b/backend/scripts/updateVideo.ts
@@ -14,8 +14,6 @@ export async function updateVideo({
   published,
 }: Partial<VideoType>) {
   try {
-    const videoUrl = convertVideoUrl(url)
-
     const currentVideo = await prisma.video.findUnique({
       where: { id },
       select: { order: true },
@@ -63,7 +61,7 @@ export async function updateVideo({
         name,
         description,
         order: newOrder !== undefined ? newOrder : currentOrder,
-        url: videoUrl,
+        url: convertVideoUrl(url),
         published,
       },
     })


### PR DESCRIPTION
## 概要
・本来こちらの[PR](https://github.com/ishida-frontend/engineer-tenshoku-master/pull/119)でpushすべきだった修正

## 実装する理由・変更する理由
・こちらの[PR](https://github.com/ishida-frontend/engineer-tenshoku-master/pull/119)で、誤って修正をpushせずにmergeをしてしまったため。