### PR TITLE
Headerのボタンを小さくする

### DIFF
--- a/frontend/components/organisms/HeaderLoggedOut.tsx
+++ b/frontend/components/organisms/HeaderLoggedOut.tsx
@@ -28,9 +28,9 @@ export function HeaderLoggedOut() {
           <HStack spacing="40px" pr="40px">
             <Link href="/auth/login">
               <Button
-                w="144px"
-                h="64px"
-                fontSize="24px"
+                w="120"
+                h="48px"
+                fontSize="18px"
                 bg="green.500"
                 color="white"
                 borderRadius="12px"
@@ -40,9 +40,9 @@ export function HeaderLoggedOut() {
             </Link>
             <Link href="/auth/register">
               <Button
-                w="144px"
-                h="64px"
-                fontSize="24px"
+                w="120"
+                h="48px"
+                fontSize="18px"
                 bg="white"
                 border="1px"
                 borderColor="blackAlpha.400"


### PR DESCRIPTION
## 概要
ヘッダーのボタン（ログイン、新規登録）の縮小化

## 実装する理由・変更する理由
ボタンのサイズが大きく、タイトルよりも目を引いてしまうため。

## UI変更前後のスクショ・機能実行結果のスクショ
修正前
<img width="1491" alt="Screen Shot 2023-09-21 at 22 59 34" src="https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/fbc24182-5ed5-4114-989b-bb3a644322d5">
修正後
<img width="1469" alt="Screen Shot 2023-09-21 at 23 06 48" src="https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/2f94572a-5426-452b-a3a4-33320e5fe557">