### PR TITLE
Update: ヘッダーのユーザメニュー更新

### DIFF
--- a/frontend/components/organisms/HeaderLoggedIn.tsx
+++ b/frontend/components/organisms/HeaderLoggedIn.tsx
@@ -107,7 +107,7 @@ export function HeaderLoggedIn({ user, signOut }: HeaderLoggedInType) {
                     text="プロフィール"
                   />
                   <MenuLinkItem
-                    path={`${PATHS.FAVORITE_VIDEO.path}`}
+                    path={`${PATHS.VIDEO.FAVORITE.path}`}
                     icon={<AiOutlineStar />}
                     text="お気に入り動画"
                   />

--- a/frontend/components/organisms/HeaderLoggedIn.tsx
+++ b/frontend/components/organisms/HeaderLoggedIn.tsx
@@ -2,17 +2,24 @@
 import {
   Avatar,
   Box,
-  Card,
   Flex,
   Heading,
   HStack,
+  Link,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
   Spacer,
   Text,
+  Tooltip,
 } from '@chakra-ui/react'
 import { AiOutlineUser } from 'react-icons/ai'
+import { AiOutlineStar } from 'react-icons/ai'
+import { FiLogOut } from 'react-icons/fi'
 
 import { TitleLogo } from '../atoms/TitleLogo'
-import { useState } from 'react'
+import { FC, ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import { PATHS } from '../../constants/paths'
 
@@ -24,9 +31,41 @@ type HeaderLoggedInType = {
   }
   signOut: () => Promise<void>
 }
+
+type MenuLinkItemProps = {
+  path?: string
+  icon: ReactNode
+  text: string
+  onClick?: () => void
+}
+
 export function HeaderLoggedIn({ user, signOut }: HeaderLoggedInType) {
-  const [show, setShow] = useState(false)
   const router = useRouter()
+
+  const MenuLinkItem: FC<MenuLinkItemProps> = ({
+    path,
+    icon,
+    text,
+    onClick,
+  }) => {
+    return path ? (
+      <Link href={path} _hover={{ textDecoration: 'none' }}>
+        <MenuItem>
+          <HStack>
+            {icon}
+            <Text>{text}</Text>
+          </HStack>
+        </MenuItem>
+      </Link>
+    ) : (
+      <MenuItem onClick={onClick}>
+        <HStack>
+          {icon}
+          <Text>{text}</Text>
+        </HStack>
+      </MenuItem>
+    )
+  }
 
   const handleLogout = async () => {
     await signOut()
@@ -47,32 +86,38 @@ export function HeaderLoggedIn({ user, signOut }: HeaderLoggedInType) {
               </Heading>
             </HStack>
             <Spacer />
-            <HStack
-              pr="36px"
-              onMouseEnter={() => setShow(true)}
-              onMouseLeave={() => setShow(false)}
-              position={'relative'}
-            >
-              {/* TODO:プロフィールページへのリンクを貼る */}
+            <HStack pr="36px">
               <Box fontSize={'20px'} marginRight={'8px'}>
                 {user.name}
               </Box>
-              <Avatar
-                bg="blue.300"
-                color="black"
-                icon={<AiOutlineUser fontSize="2rem" />}
-              />
-              {show && (
-                <Card
-                  position={'absolute'}
-                  top={'40px'}
-                  right={'0'}
-                  width={'200px'}
-                >
-                  表示されるメニュー
-                  <Text onClick={handleLogout}>ログアウト</Text>
-                </Card>
-              )}
+              <Menu>
+                <Tooltip label="メニュー">
+                  <MenuButton>
+                    <Avatar
+                      bg="blue.300"
+                      color="black"
+                      icon={<AiOutlineUser fontSize="2rem" />}
+                    />
+                  </MenuButton>
+                </Tooltip>
+                <MenuList>
+                  <MenuLinkItem
+                    path={`${PATHS.PROFILE.path}`}
+                    icon={<AiOutlineUser />}
+                    text="プロフィール"
+                  />
+                  <MenuLinkItem
+                    path={`${PATHS.FAVORITE_VIDEO.path}`}
+                    icon={<AiOutlineStar />}
+                    text="お気に入り動画"
+                  />
+                  <MenuLinkItem
+                    icon={<FiLogOut />}
+                    text="ログアウト"
+                    onClick={handleLogout}
+                  />
+                </MenuList>
+              </Menu>
             </HStack>
           </HStack>
         </Flex>

--- a/frontend/constants/paths.ts
+++ b/frontend/constants/paths.ts
@@ -29,9 +29,11 @@ export const PATHS = {
     path: '/profile',
     title: 'プロフィール',
   },
-  FAVORITE_VIDEO: {
-    path: '/videos/favorite',
-    title: 'プロフィール',
+  VIDEO: {
+    FAVORITE: {
+      path: '/videos/favorite',
+      title: 'お気に入り動画一覧',
+    },
   },
   ADMIN: {
     COURSE: {

--- a/frontend/constants/paths.ts
+++ b/frontend/constants/paths.ts
@@ -29,6 +29,10 @@ export const PATHS = {
     path: '/profile',
     title: 'プロフィール',
   },
+  FAVORITE_VIDEO: {
+    path: '/videos/favorite',
+    title: 'プロフィール',
+  },
   ADMIN: {
     COURSE: {
       LIST: {


### PR DESCRIPTION
## 概要
- プロフィールページへのリンク追加
- お気に入り動画ページへのリンク追加
- メニューデザインの変更

## 実装する理由・変更する理由
ユーザが使いたいページへすぐに移動できるようにするため

## 動作確認動画
各リンクからの遷移した時の様子

https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/e479196a-297a-4157-ac6c-b523daa49881



## コメント
ログアウト後の遷移が不安定なので別タスクで対応。
（本来であればログイン画面に遷移）
