### PR TITLE
Fix: ログアウト後にログイン画面に遷移するよう修正

### DIFF
--- a/frontend/app/main.tsx
+++ b/frontend/app/main.tsx
@@ -1,6 +1,7 @@
 import { Loader } from '../components/atoms/Loader'
 import { Header } from './header'
 import { Footer } from '../components/organisms/Footer'
+import { PATHS } from '../constants/paths'
 import { useSession, signOut } from 'next-auth/react'
 
 export const Main = ({ children }: { children: React.ReactNode }) => {
@@ -16,9 +17,11 @@ export const Main = ({ children }: { children: React.ReactNode }) => {
     name: string
   }
 
+  const triggerSignOut = () => signOut({ callbackUrl: PATHS.LOGIN.path })
+
   return (
     <>
-      <Header user={user} signOut={signOut} />
+      <Header user={user} signOut={triggerSignOut} />
       {children}
       <Footer />
     </>

--- a/frontend/components/organisms/HeaderLoggedIn.tsx
+++ b/frontend/components/organisms/HeaderLoggedIn.tsx
@@ -20,7 +20,6 @@ import { FiLogOut } from 'react-icons/fi'
 
 import { TitleLogo } from '../atoms/TitleLogo'
 import { FC, ReactNode } from 'react'
-import { useRouter } from 'next/navigation'
 import { PATHS } from '../../constants/paths'
 
 type HeaderLoggedInType = {
@@ -40,8 +39,6 @@ type MenuLinkItemProps = {
 }
 
 export function HeaderLoggedIn({ user, signOut }: HeaderLoggedInType) {
-  const router = useRouter()
-
   const MenuLinkItem: FC<MenuLinkItemProps> = ({
     path,
     icon,
@@ -69,7 +66,6 @@ export function HeaderLoggedIn({ user, signOut }: HeaderLoggedInType) {
 
   const handleLogout = async () => {
     await signOut()
-    router.push(PATHS.LOGIN.path)
   }
 
   return (


### PR DESCRIPTION
## 概要
ログアウト後にエラーページ（frontend/app/error.tsx）が表示されるバグの修正

## 実装する理由・変更する理由
本来であればログインページに遷移されるから

## 修正後の動作確認動画

https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/3a5f1e32-0704-48ad-8845-78c3d703b134
