### PR TITLE
Update: ヘッダータイトルにトップページへのリンク追加

### DIFF
--- a/frontend/components/organisms/HeaderLoggedIn.tsx
+++ b/frontend/components/organisms/HeaderLoggedIn.tsx
@@ -77,9 +77,11 @@ export function HeaderLoggedIn({ user, signOut }: HeaderLoggedInType) {
               <Box pl="22px">
                 <TitleLogo boxSize="62px" />
               </Box>
-              <Heading as="h1" fontSize="30px" fontWeight="400" pl="17px">
-                JS学習プラットフォーム
-              </Heading>
+              <Link href="/" _hover={{ textDecoration: 'none' }}>
+                <Heading as="h1" fontSize="30px" fontWeight="400" pl="17px">
+                  JS学習プラットフォーム
+                </Heading>
+              </Link>
             </HStack>
             <Spacer />
             <HStack pr="36px">

--- a/frontend/components/organisms/HeaderLoggedOut.tsx
+++ b/frontend/components/organisms/HeaderLoggedOut.tsx
@@ -20,9 +20,11 @@ export function HeaderLoggedOut() {
             <Box pl="22px">
               <TitleLogo boxSize="62px" />
             </Box>
-            <Heading as="h1" fontSize="30px" fontWeight="400" pl="17px">
-              JS学習プラットフォーム
-            </Heading>
+            <Link href="/" _hover={{ textDecoration: 'none' }}>
+              <Heading as="h1" fontSize="30px" fontWeight="400" pl="17px">
+                JS学習プラットフォーム
+              </Heading>
+            </Link>
           </HStack>
           <Spacer />
           <HStack spacing="40px" pr="40px">


### PR DESCRIPTION
## 概要
ヘッダータイトルにトップページ（/)へのリンクを追加

## 実装する理由・変更する理由
ユーザがどのページからでもトップページへアクセスできるようにするため

## 動作確認用動画
ログイン済みヘッダーでクリック→ログアウトヘッダーでクリック

https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/d28edf35-96c9-408d-a527-ed9b2ceb703f



## コメント
2023/10/20時点：トップページ（/）へアクセスするとコース一覧（/course）にリダイレクトされる設定。