### PR TITLE
Fix: Huskyでコミット前にESLintが走るようにする

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# ここにコミット前に走らせたい処理を入れる
-cd frontend && yarn lint
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "scripts": {
     "prepare": "husky install"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": "eslint --fix"
   }
 }


### PR DESCRIPTION
## 概要
Huskyでコミット前にESLintが走るように修正
リント対象ファイルはステージされた`.tx .tsx`ファイル

## 実装する理由・変更する理由
前回の設定では想定どおりの動作をしていなかったため

## UI変更前後のスクショ・機能実行結果のスクショ
コミット時にリントエラーが出てコミットできない様子

![Screenshot 2023-10-23 at 12 04 45](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/12f5d0d3-45cf-4d40-bff5-cfc46c598a0e)
