### PR TITLE
メールアドレス変更認証コード画面（フロント側）

### DIFF
--- a/frontend/app/email/confirm/page.tsx
+++ b/frontend/app/email/confirm/page.tsx
@@ -20,7 +20,7 @@ export default function EmailChangeConfirmPage() {
         </Heading>
 
         <Box mb="28px">
-          新しいメールアドレス宛てに送信した認証コードを入力してください。
+          新しいメールアドレス宛に送信した認証コードを入力してください。
         </Box>
 
         <FormControl id="verificationCode" mb="42px" isRequired>

--- a/frontend/app/email/confirm/page.tsx
+++ b/frontend/app/email/confirm/page.tsx
@@ -1,0 +1,49 @@
+'use client'
+import {
+  Box,
+  Button,
+  Center,
+  Container,
+  FormControl,
+  Heading,
+  Input,
+  Link,
+} from '@chakra-ui/react'
+import NextLink from 'next/link'
+
+export default function EmailChangeConfirmPage() {
+  return (
+    <Center padding="60px 96px" bg={'gray.200'}>
+      <Container padding="60px 96px" bg={'white'}>
+        <Heading fontSize="2xl" mb="60px" textAlign="center" fontWeight="bold">
+          認証コードを入力
+        </Heading>
+
+        <Box mb="28px">
+          新しいメールアドレス宛てに送信した認証コードを入力してください。
+        </Box>
+
+        <FormControl id="verificationCode" mb="42px" isRequired>
+          <Input
+            id="verificationCode"
+            type="text"
+            aria-required={true}
+            border="1px"
+            borderColor="gray.400"
+            placeholder="認証コード"
+          />
+        </FormControl>
+
+        <Button w="100%" mb="42px" colorScheme="teal">
+          認証する
+        </Button>
+
+        <Box color="teal">
+          <Link as={NextLink} href="/auth/login">
+            ログイン
+          </Link>
+        </Box>
+      </Container>
+    </Center>
+  )
+}


### PR DESCRIPTION
## 概要
メールアドレス変更時に送られる認証コードを入力して認証する画面

## 実装理由・変更理由
- 変更後のメールアドレスが変更者本人のものであるか確認するため
- ユーザーアカウントへの不正アクセス防止のため

## 実装画面のスクショ

![Screenshot 2023-11-15 at 0 01 33](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/df551dbf-b7a7-4890-b636-a5b03a5d5e5b)