### PR TITLE
backend/dist/ を gitignore へ追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .next
 .vscode/
 */package-lock.json
+backend/dist/


### PR DESCRIPTION
## 概要
backendディレクトリをbuildした際に生成される`dist`ディレクトリをgitignoreへ追加

## 実装理由・変更理由
同ディレクトリをgitで管理する必要がないため

## 機能実行結果のスクショ
ローカルでbuild後、該当ディレクトリがグレーアウトされているのを確認しましました。

![Screenshot 2023-11-18 at 10 20 15](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/3e76c201-71ea-4996-a764-5fa90520ba24)

