### PR TITLE
Jest導入＆テストを１つ準備

### DIFF
--- a/backend/__tests__/application/tag.test.ts
+++ b/backend/__tests__/application/tag.test.ts
@@ -1,0 +1,45 @@
+import { prismaMock } from '../singleton'
+import { TagApplicationService } from '../../application/tag'
+
+let tagService: TagApplicationService
+
+beforeEach(() => {
+  tagService = new TagApplicationService(prismaMock)
+})
+
+test('タグの新規作成が成功すること', async () => {
+  const tagParams = {
+    name: 'Node.js',
+    color: 'white',
+    backgroundColor: 'green',
+  }
+
+  const expectedTag = {
+    id: expect.any(String),
+    name: 'Node.js',
+    color: 'white',
+    backgroundColor: 'green',
+    created_at: expect.any(Date),
+    updated_at: expect.any(Date),
+    deleted_at: null,
+    courseId: null,
+  }
+
+  prismaMock.tag.create.mockResolvedValue(expectedTag)
+
+  const createdTag = await tagService.createTag(tagParams)
+  expect(createdTag).toEqual(expectedTag)
+})
+
+test('タグの新規作成に失敗した際にエラーが投げられること', async () => {
+  const tagParams = {
+    name: 'Node.js',
+    color: 'white',
+    backgroundColor: 'green',
+  }
+
+  const errorMessage = 'タグの新規作成に失敗しました'
+  prismaMock.tag.create.mockRejectedValue(new Error(errorMessage))
+
+  await expect(tagService.createTag(tagParams)).rejects.toThrow(errorMessage)
+})

--- a/backend/__tests__/singleton.ts
+++ b/backend/__tests__/singleton.ts
@@ -1,0 +1,14 @@
+import { mockDeep, mockReset, DeepMockProxy } from 'jest-mock-extended'
+
+import prisma, { PrismaClient } from '../utils/prismaClient'
+
+jest.mock('../utils/prismaClient', () => ({
+  __esModule: true,
+  default: mockDeep<PrismaClient>(),
+}))
+
+beforeEach(() => {
+  mockReset(prismaMock)
+})
+
+export const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>

--- a/backend/application/tag.ts
+++ b/backend/application/tag.ts
@@ -1,7 +1,12 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma, { PrismaClient } from '../utils/prismaClient'
 
 export class TagApplicationService {
+  private prisma: PrismaClient
+
+  constructor(prismaClient: PrismaClient = prisma) {
+    this.prisma = prismaClient
+  }
+
   async createTag(params: {
     name: string
     color: string
@@ -9,7 +14,7 @@ export class TagApplicationService {
   }) {
     try {
       const { name, color, backgroundColor } = params
-      const question = await prisma.tag.create({
+      const question = await this.prisma.tag.create({
         data: {
           name,
           color,
@@ -21,6 +26,7 @@ export class TagApplicationService {
       throw error
     }
   }
+
   async updateTag(params: {
     id: string
     name: string
@@ -29,7 +35,7 @@ export class TagApplicationService {
   }) {
     try {
       const { id, name, color, backgroundColor } = params
-      const tag = await prisma.tag.update({
+      const tag = await this.prisma.tag.update({
         where: { id },
         data: {
           name,
@@ -45,7 +51,7 @@ export class TagApplicationService {
 
   async getTag(tagId: string) {
     try {
-      const question = await prisma.tag.findUnique({
+      const question = await this.prisma.tag.findUnique({
         where: { id: tagId },
       })
       return question
@@ -53,9 +59,10 @@ export class TagApplicationService {
       throw error
     }
   }
+
   async getTags() {
     try {
-      const question = await prisma.tag.findMany({
+      const question = await this.prisma.tag.findMany({
         where: { deleted_at: null },
       })
       return question

--- a/backend/controllers/tagController.ts
+++ b/backend/controllers/tagController.ts
@@ -1,10 +1,11 @@
 import express from 'express'
 import { TagApplicationService } from '../application/tag'
+import prisma from '../utils/prismaClient'
 
 export class TagController {
   private tagApplicationService: TagApplicationService
   constructor() {
-    this.tagApplicationService = new TagApplicationService()
+    this.tagApplicationService = new TagApplicationService(prisma)
   }
   async createTag(req: express.Request, res: express.Response) {
     try {

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+import { JestConfigWithTsJest } from 'ts-jest'
+
+const config: JestConfigWithTsJest = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/__tests__/singleton.ts'],
+}
+
+export default config

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "nodemon app.ts",
     "build": "tsc",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "createVideo": "nodemon ./scripts/createVideo.ts",
     "readVideo": "nodemon ./scripts/readVideo.ts",
     "updateVideo": "nodemon ./scripts/updateVideo.ts",
@@ -35,6 +35,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",
+    "jest-mock-extended": "^3.0.5",
     "jsonwebtoken": "^9.0.1",
     "mysql": "^2.18.1",
     "nodemon": "^3.0.1",
@@ -45,13 +46,17 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
+    "@jest/globals": "^29.7.0",
     "@types/cors": "^2.8.13",
+    "@types/jest": "^29.5.8",
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "@typescript-eslint/parser": "^6.2.1",
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^8.9.0",
     "eslint-plugin-prettier": "^5.0.0",
-    "prettier": "^3.0.0"
+    "jest": "^29.7.0",
+    "prettier": "^3.0.0",
+    "ts-jest": "^29.1.1"
   },
   "prisma": {
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed/index.ts"

--- a/backend/utils/prismaClient.ts
+++ b/backend/utils/prismaClient.ts
@@ -1,0 +1,6 @@
+import { PrismaClient } from '@prisma/client'
+
+export { PrismaClient }
+
+const prisma = new PrismaClient()
+export default prisma


### PR DESCRIPTION
## 概要

- Jestの導入
- createTag関数の単体テスト

## 実装理由・変更理由
将来的にJestをCI/CDの一環で利用するための準備として

## 設計
- テスト対象
`createTag`メソッド in `backend/application/tag.ts/`

- テストファイル
`backend/__tests__/application/tag.test.ts`
（テスト対象のディレクトリ構造、ディレクトリ名、ファイル名を踏襲）

- テスト項目
1. 新規タグ作成に成功すること
2. 新規タグ作成失敗時にerrorが投げられること

## 機能実行結果のスクショ（２つのテストを通過）
![Screenshot 2023-11-25 at 15 03 20](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/d56e9820-aea8-4769-8223-b811ca3aecd2)

## コメント
- テスト実行手順

1. `backend`で`yarn`コマンドを実行し関連ライブラリを追加
2. `backend`で`yarn test`コマンド → `backend/__tests__`内のテストが全て実行される

- Prisma公式ドキュメントの「[Singletonを使った単体テスト](https://www.prisma.io/docs/guides/testing/unit-testing#singleton)」についてのページを参考に実装しました。
  - `backend/utils/prismaClient.ts`： Prisma client を export し、必要なファイルで import する形にしました。理由は、実際のDBを操作する Prisima client と、テストで使用する Prisma client モックの置き換えを容易にするためです。
  - `backend/__tests__/singleton.ts`：Prisma client をモックに置き換えています。
  - `backend/application/tag.ts`：`TagApplicationService`クラスにコンストラクタを定義し、同クラスのインスタンス化時に引数で「本物の Prisima client（prisma）」か「モックの Prisma client （prismaMock）」を指定します。
  - `backend/__tests__/application/tag.test.ts`：Prisma client モックと、`TagApplicationService`クラスを import として、createTagメソッドのテストしています。