### PR TITLE
Prisma Client を utils ディレクトリから呼び出すように変更

### DIFF
--- a/backend/application/answer.ts
+++ b/backend/application/answer.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export class AnswerApplicationService {
   static async create(body: {

--- a/backend/application/favoriteVideo.ts
+++ b/backend/application/favoriteVideo.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export class FavoriteVideoApplicationService {
   static async upsert({

--- a/backend/application/question.ts
+++ b/backend/application/question.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export class QuestionApplicationService {
   static async create(body: {

--- a/backend/application/user.ts
+++ b/backend/application/user.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export class UserApplicationService {
   static async create(params: { id: string; name: string }) {

--- a/backend/application/viewingStatus.ts
+++ b/backend/application/viewingStatus.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 type ViewingStatusesType = {
   video_id: string

--- a/backend/controllers/contactController.ts
+++ b/backend/controllers/contactController.ts
@@ -1,9 +1,7 @@
-import express, { Request, Response, NextFunction } from 'express'
-import { PrismaClient } from '@prisma/client'
+import express, { Request, Response } from 'express'
 import { readAllContacts } from '../scripts/readContact'
 import { createContact } from '../scripts/createContact'
 
-const prisma = new PrismaClient()
 const router = express.Router()
 
 exports.checkCreateContact = async function (req: Request, res: Response) {

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -121,13 +121,13 @@ exports.updateCourse = async function (
   try {
     const { id, name, description, published, tagIds } = req.body
 
-    const response = await updateCourse(
+    const response = await updateCourse({
       id,
       name,
       description,
       published,
       tagIds,
-    )
+    })
 
     res.status(200).json({ message: '変更が保存されました。' })
   } catch (error) {

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -121,13 +121,13 @@ exports.updateCourse = async function (
   try {
     const { id, name, description, published, tagIds } = req.body
 
-    const response = await updateCourse({
+    const response = await updateCourse(
       id,
       name,
       description,
       published,
       tagIds,
-    })
+    )
 
     res.status(200).json({ message: '変更が保存されました。' })
   } catch (error) {

--- a/backend/prisma/seed/index.ts
+++ b/backend/prisma/seed/index.ts
@@ -1,7 +1,6 @@
-import { PrismaClient } from '@prisma/client'
+import prisma from '../../utils/prismaClient'
 import crypto from 'crypto'
 import { THEME_COLOR } from '../../constants'
-const prisma = new PrismaClient()
 
 async function main() {
   for (let i: number = 1; i <= 5; i++) {

--- a/backend/scripts/createContact.ts
+++ b/backend/scripts/createContact.ts
@@ -1,7 +1,6 @@
 import axios from 'axios'
-import { PrismaClient } from '@prisma/client'
+import prisma from '../utils/prismaClient'
 import { ContactType } from '../types/index'
-const prisma = new PrismaClient()
 
 type createContactParamsType = {
   name: string

--- a/backend/scripts/createCourse.ts
+++ b/backend/scripts/createCourse.ts
@@ -1,6 +1,5 @@
-import { PrismaClient } from '@prisma/client'
+import prisma from '../utils/prismaClient'
 import crypto from 'crypto'
-const prisma = new PrismaClient()
 
 export async function createCourse(
   name: string,

--- a/backend/scripts/createSection.ts
+++ b/backend/scripts/createSection.ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from '@prisma/client'
+import prisma from '../utils/prismaClient'
 import crypto from 'crypto'
-
-const prisma = new PrismaClient()
 
 export async function createSection(sectionData: {
   course_id: string

--- a/backend/scripts/createVideo.ts
+++ b/backend/scripts/createVideo.ts
@@ -1,9 +1,7 @@
-import { PrismaClient } from '@prisma/client'
 import { convertVideoUrl } from '../utils/convertVideoUrl'
 import { VideoType } from '../types'
 import crypto from 'crypto'
-
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export async function createVideo(videoData: VideoType) {
   try {

--- a/backend/scripts/deleteCourse.ts
+++ b/backend/scripts/deleteCourse.ts
@@ -1,7 +1,4 @@
-import express from 'express'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 prisma.$use(async (params, next) => {
   if (params.model === 'Course') {

--- a/backend/scripts/deleteSection.ts
+++ b/backend/scripts/deleteSection.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 prisma.$use(async (params, next) => {
   if (params.model === 'Section') {

--- a/backend/scripts/deleteVideo.ts
+++ b/backend/scripts/deleteVideo.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 prisma.$use(async (params, next) => {
   if (params.model === 'Video') {

--- a/backend/scripts/readContact.ts
+++ b/backend/scripts/readContact.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export async function readAllContacts() {
   const contacts = await prisma.contact.findMany({

--- a/backend/scripts/readCourse.ts
+++ b/backend/scripts/readCourse.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export async function readCourse(id: string) {
   const course = await prisma.course.findUnique({

--- a/backend/scripts/readSection.ts
+++ b/backend/scripts/readSection.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export async function readSection(sectionId: string) {
   const section = await prisma.section.findUnique({

--- a/backend/scripts/readVideo.ts
+++ b/backend/scripts/readVideo.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export async function readVideo(id: string) {
   const video = await prisma.video.findUnique({

--- a/backend/scripts/updateCourse.ts
+++ b/backend/scripts/updateCourse.ts
@@ -1,12 +1,17 @@
-import prisma from '../utils/prismaClient'
+import prisma, { Prisma } from '../utils/prismaClient'
 
-export async function updateCourse(
-  id: string,
-  name: string,
-  description: string,
-  published: boolean,
-  tagIds: string[],
-) {
+type CourseUpdateInput = Prisma.CourseUpdateInput & {
+  id: string
+  tagIds: string[]
+}
+
+export async function updateCourse({
+  id,
+  name,
+  description,
+  published,
+  tagIds,
+}: CourseUpdateInput) {
   try {
     const targetCourse = await prisma.course.findUnique({
       where: {

--- a/backend/scripts/updateCourse.ts
+++ b/backend/scripts/updateCourse.ts
@@ -1,17 +1,12 @@
-import prisma, { Prisma } from '../utils/prismaClient'
+import prisma from '../utils/prismaClient'
 
-type CourseUpdateInput = Prisma.CourseUpdateInput & {
-  id: string
-  tagIds: string[]
-}
-
-export async function updateCourse({
-  id,
-  name,
-  description,
-  published,
-  tagIds,
-}: CourseUpdateInput) {
+export async function updateCourse(
+  id: string,
+  name: string,
+  description: string,
+  published: boolean,
+  tagIds: string[],
+) {
   try {
     const targetCourse = await prisma.course.findUnique({
       where: {

--- a/backend/scripts/updateCourse.ts
+++ b/backend/scripts/updateCourse.ts
@@ -1,6 +1,4 @@
-import { Prisma, PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import prisma, { Prisma } from '../utils/prismaClient'
 
 type CourseUpdateInput = Prisma.CourseUpdateInput & {
   id: string

--- a/backend/scripts/updateSection.ts
+++ b/backend/scripts/updateSection.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client'
-const prisma = new PrismaClient()
+import prisma from '../utils/prismaClient'
 
 export async function updateSection(section_id: string) {
   const section = await prisma.section.update({

--- a/backend/scripts/updateVideo.ts
+++ b/backend/scripts/updateVideo.ts
@@ -1,8 +1,6 @@
-import { PrismaClient } from '@prisma/client'
+import prisma from '../utils/prismaClient'
 import { convertVideoUrl } from '../utils/convertVideoUrl'
 import { VideoType } from '../types'
-
-const prisma = new PrismaClient()
 
 export async function updateVideo({
   id,

--- a/backend/utils/prismaClient.ts
+++ b/backend/utils/prismaClient.ts
@@ -1,7 +1,6 @@
-import { PrismaClient, Prisma } from '@prisma/client'
+import { PrismaClient } from '@prisma/client'
 
 export { PrismaClient }
-export { Prisma }
 
 const prisma = new PrismaClient()
 export default prisma

--- a/backend/utils/prismaClient.ts
+++ b/backend/utils/prismaClient.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client'
 
-export { PrismaClient }
+export { PrismaClient, Prisma }
 
 const prisma = new PrismaClient()
 export default prisma

--- a/backend/utils/prismaClient.ts
+++ b/backend/utils/prismaClient.ts
@@ -1,6 +1,7 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, Prisma } from '@prisma/client'
 
 export { PrismaClient }
+export { Prisma }
 
 const prisma = new PrismaClient()
 export default prisma


### PR DESCRIPTION
## 概要
Prisma Client を `backend/utils/prismaClient.ts` から呼び出すように変更
対象ファイル：Prisma Clientを読み込んでいるファイル全て

## 実装理由・変更理由
- Jestでのテスト時に Prisma Client のモックへの切り替えをスムーズにするため

## コメント
- [backend/utils/prismaClient.ts](https://github.com/ishida-frontend/engineer-tenshoku-master/pull/220/commits/a67f334563f0619ee243190196aa9e6ef373ee6c#diff-08f852eb3cfc42aeb22c6a5ff5809123c58af2e7133890e98e08b2ef791a9c41)：Prisma名前空間を追加（理由：[backend/scripts/updateCourse.ts](https://github.com/ishida-frontend/engineer-tenshoku-master/pull/220/files#diff-91c7e82c4804b4f70e259bb0a3ed7c0b7a26d516ad90f02ca48c4afa3ef8adc0)で必要なため）
- 以下のファイルにあった「定義したが未使用の変数」を削除
  - [backend/controllers/contactController.ts](https://github.com/ishida-frontend/engineer-tenshoku-master/pull/220/commits/a67f334563f0619ee243190196aa9e6ef373ee6c#diff-7e51e66708d7a75dcca0874e89a6936c906d1ba7f2456ae4b4d5b9d09b28681d): `NextFunction`
  - [backend/scripts/deleteCourse.ts](https://github.com/ishida-frontend/engineer-tenshoku-master/pull/220/commits/a67f334563f0619ee243190196aa9e6ef373ee6c#diff-08f852eb3cfc42aeb22c6a5ff5809123c58af2e7133890e98e08b2ef791a9c41): `import express from 'express'`
