### PR TITLE
各ページの背景色をmain.tsxで一括指定する

### DIFF
--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -53,7 +53,7 @@ export default function Login() {
   }, [status])
 
   return (
-    <Center padding="60px 96px" bg={'gray.200'}>
+    <Center padding="60px 96px">
       <Container padding="60px 96px" bg={'white'}>
         <Heading
           fontSize={'2xl'}

--- a/frontend/app/auth/register/page.tsx
+++ b/frontend/app/auth/register/page.tsx
@@ -74,7 +74,7 @@ export default function Register() {
   }, [status])
 
   return (
-    <Center padding="60px 96px" bg={'gray.200'}>
+    <Center padding="60px 96px">
       <Container padding="60px 96px" bg={'white'}>
         <Heading
           fontSize={'2xl'}

--- a/frontend/app/email/confirm/page.tsx
+++ b/frontend/app/email/confirm/page.tsx
@@ -13,7 +13,7 @@ import NextLink from 'next/link'
 
 export default function EmailChangeConfirmPage() {
   return (
-    <Center padding="60px 96px" bg={'gray.200'}>
+    <Center padding="60px 96px">
       <Container padding="60px 96px" bg={'white'}>
         <Heading fontSize="2xl" mb="60px" textAlign="center" fontWeight="bold">
           認証コードを入力

--- a/frontend/app/main.tsx
+++ b/frontend/app/main.tsx
@@ -23,7 +23,9 @@ export const Main = ({ children }: { children: React.ReactNode }) => {
   return (
     <Flex direction="column" minH="100vh">
       <Header user={user} signOut={triggerSignOut} />
-      <Box flex="1">{children}</Box>
+      <Box flex="1" bg="gray.200">
+        {children}
+      </Box>
       <Footer />
     </Flex>
   )

--- a/frontend/components/admin/organisms/SectionManage.tsx
+++ b/frontend/components/admin/organisms/SectionManage.tsx
@@ -174,7 +174,7 @@ export function SectionManage({
   }
 
   return (
-    <Center minH={'100vh'} bg={'gray.200'}>
+    <Center minH={'100vh'}>
       <Container bg="white" minW={'100vh'} centerContent>
         <Heading fontSize={'2xl'} fontWeight={'bold'} mt={'80px'}>
           コース内容

--- a/frontend/components/pages/CourseList.tsx
+++ b/frontend/components/pages/CourseList.tsx
@@ -39,7 +39,7 @@ export function CourseList({ courses, handleTextChange }: CourseListProps) {
   }
 
   return (
-    <Center bg={'gray.200'}>
+    <Center>
       <VStack mx="auto" padding={'60px 96px'}>
         <Heading py={10} color={PRIMARY_FONT_COLOR} fontSize="36px">
           コース一覧

--- a/frontend/components/pages/FavoriteVideoList.tsx
+++ b/frontend/components/pages/FavoriteVideoList.tsx
@@ -37,7 +37,7 @@ export function FavoriteVideoList({ favoriteVideos }: FavoriteVideoListProps) {
     .filter((course) => course.sections.length > 0)
 
   return (
-    <Center bg={'gray.200'}>
+    <Center>
       <VStack mx="auto" padding={'60px 96px'}>
         <Heading my={5} color={PRIMARY_FONT_COLOR} fontSize="36px">
           お気に入り動画一覧


### PR DESCRIPTION
## 概要
[frontend/app/main.tsx](https://github.com/ishida-frontend/engineer-tenshoku-master/pull/222/files#diff-97874d67759384dd7b31afca6a66b13e7dd53f39a49130764d564ce52799d58a) で各ページの背景色を一括指定する。
背景色：#E2E8F0（[Chakra UI: gray.200](https://chakra-ui.com/docs/styled-system/theme))

## 実装理由・変更理由
- ページ背景色を一元管理するため
- 背景色が適用されていない箇所の修正のため

## コメント
- 以下のファイルに個別で指定されていた `bg={'gray.200'}` を削除しました。
  - `frontend/components/pages/CourseList.tsx`
  - `frontend/components/pages/FavoriteVideoList.tsx`
  - `frontend/app/auth/login/page.tsx`
  - `frontend/app/auth/register/page.tsx`
  - `frontend/app/email/confirm/page.tsx`
  - `frontend/components/admin/organisms/SectionManage.tsx`