### PR TITLE
未ログイン時にコース詳細ページが表示されない不具合の修正

### DIFF
--- a/frontend/components/organisms/CourseDetailAccordionMenu.tsx
+++ b/frontend/components/organisms/CourseDetailAccordionMenu.tsx
@@ -38,7 +38,7 @@ export function CourseDetailAccordionMenu({
 }) {
   return (
     <Box w={'427px'} float={'right'} bg={'white'}>
-      {session.user.id && (
+      {session?.user?.id && (
         <Center
           minH="60px"
           bg="gray.100"
@@ -92,7 +92,7 @@ export function CourseDetailAccordionMenu({
                             >
                               <CardHeader>
                                 <HStack>
-                                  {session.user.id && (
+                                  {session?.user?.id && (
                                     <WatchedCheckCircle
                                       checkedStatus={
                                         checkedStatus?.[video.id] || false

--- a/frontend/components/organisms/CourseDetailVideoSection.tsx
+++ b/frontend/components/organisms/CourseDetailVideoSection.tsx
@@ -88,7 +88,7 @@ export function CourseDetailVideoSection({
               <Text pl={'40px'}>{selectedVideo?.sections.videos.order}.</Text>
               <Text pl={'3px'}>{selectedVideo?.sections.videos.name}</Text>
               <Spacer />
-              {session.user.id && selectedVideo && (
+              {session?.user?.id && selectedVideo && (
                 <>
                   <WatchedButton
                     watchedStatus={


### PR DESCRIPTION
## バグ
未ログイン時にコース詳細ページが表示されない。

## 原因
未ログインだとsessionがnullになり、sessionの有無で要素の表示管理をしている箇所でTypeErrorが発生するため。

- エラー
```
TypeError: Cannot read properties of null (reading 'user')
```
- エラー発生箇所例
```
{session.user.id && (
  <Center>
       中略
  </Center>
)}
```

## 修正
`session.user.id`にオプショナルチェーンを付与して、`session?.user?.id`とします。
こうすることでsessionがない場合、undefinedが返され、エラーを回避してページを正常に表示させられます。