### PR TITLE
動画詳細画面をクエリパラメータからパスパラメータへ修正

### DIFF
--- a/frontend/app/course/[courseId]/[videoId]/page.tsx
+++ b/frontend/app/course/[courseId]/[videoId]/page.tsx
@@ -1,20 +1,20 @@
 import React from 'react'
 import { getServerSession } from 'next-auth/next'
 
-import { authOptions } from '../../api/auth/[...nextauth]/route'
-import { CourseWithSectionsType } from '../../../types/CourseType'
-import { CourseDetailWrapper } from '../../../components/wrapper/pages/CourseDetail'
-import { QuestionType } from '../../../types/QuestionType'
-import { AnswerType } from '../../../types/AnswerType'
-import Error from '../../error'
-import { loggerInfo } from '../../../utils/logger'
+import { authOptions } from '../../../api/auth/[...nextauth]/route'
+import { CourseWithSectionsType } from '../../../../types/CourseType'
+import { CourseDetailWrapper } from '../../../../components/wrapper/pages/CourseDetail'
+import { QuestionType } from '../../../../types/QuestionType'
+import { AnswerType } from '../../../../types/AnswerType'
+import Error from '../../../error'
+import { loggerInfo } from '../../../../utils/logger'
 
 export default async function CourseDetailPage({
   params,
   searchParams,
 }: {
-  params: { courseId: string }
-  searchParams: { videoId: string; questionId: string }
+  params: { courseId: string; videoId: string }
+  searchParams: { questionId: string }
 }) {
   const session = await getServerSession(authOptions)
   const userId = session?.user?.id
@@ -29,10 +29,11 @@ export default async function CourseDetailPage({
         },
       },
     )
+
     const initialCourseData: CourseWithSectionsType = await getCourseData.json()
 
     const getQuestionsData = await fetch(
-      `${process.env.NEXT_PUBLIC_BACKEND_URL}/question/${searchParams.videoId}`,
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/question/${params.videoId}`,
       {
         cache: 'no-cache',
         headers: {
@@ -59,7 +60,7 @@ export default async function CourseDetailPage({
         initialCourseData={initialCourseData}
         session={session}
         userId={userId}
-        videoId={searchParams.videoId}
+        videoId={params.videoId}
         questions={questions}
         answers={answers}
         questionId={searchParams.questionId}
@@ -67,7 +68,7 @@ export default async function CourseDetailPage({
     )
   } catch (e) {
     loggerInfo(`error: ${e}`, {
-      caller: 'frontend/app/course/[courseId]/page.tsx',
+      caller: 'frontend/app/course/[courseId]/[videoId]/page.tsx',
       status: 400,
     })
     return <Error />

--- a/frontend/components/atoms/CourseCard.tsx
+++ b/frontend/components/atoms/CourseCard.tsx
@@ -104,7 +104,7 @@ export function CourseCard({ courses }: CourseCardProp) {
               right={'12px'}
             >
               <Link
-                href={`/course/${course.id}?videoId=${course.sections[0]?.videos[0]?.id}`}
+                href={`/course/${course.id}/${course.sections[0]?.videos[0]?.id}`}
                 mt="2"
                 color={PRIMARY_FONT_COLOR}
                 _hover={{ textDecoration: 'none' }}

--- a/frontend/components/organisms/CourseDetailAccordionMenu.tsx
+++ b/frontend/components/organisms/CourseDetailAccordionMenu.tsx
@@ -77,7 +77,7 @@ export function CourseDetailAccordionMenu({
                         return (
                           <Link
                             key={video.id}
-                            href={`/course/${courseData.id}/?videoId=${video.id}`}
+                            href={`/course/${courseData.id}/${video.id}`}
                           >
                             <Card
                               key={video.id}

--- a/frontend/components/organisms/QuestionDetail.tsx
+++ b/frontend/components/organisms/QuestionDetail.tsx
@@ -149,7 +149,7 @@ export function QuestionDetail({
               </HStack>
             </Card>
           ))}
-          <Link href={`/course/${courseId}/?videoId=${videoId}`} scroll={false}>
+          <Link href={`/course/${courseId}/${videoId}`} scroll={false}>
             <Button
               mt={'20px'}
               onClick={() => changeQuestionPage(QUESTION_PAGES.QuestionList)}

--- a/frontend/components/organisms/QuestionList.tsx
+++ b/frontend/components/organisms/QuestionList.tsx
@@ -107,7 +107,7 @@ export function QuestionList({
                   )}
                   <Link
                     key={question.id}
-                    href={`/course/${courseId}/?videoId=${videoId}&questionId=${question.id}`}
+                    href={`/course/${courseId}/${videoId}?questionId=${question.id}`}
                     scroll={false}
                     onClick={changeToQuestionDetail}
                   >

--- a/frontend/components/pages/CourseDetail.tsx
+++ b/frontend/components/pages/CourseDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useParams } from 'next/navigation'
 import { useRouter } from 'next/navigation'
 import { Container, VStack } from '@chakra-ui/react'
 
@@ -82,8 +82,8 @@ export function CourseDetail({
 }) {
   const router = useRouter()
   const { showErrorToast } = useCustomToast()
-  const searchParams = useSearchParams()
-  const searchedVideoId = searchParams.get('videoId')
+  const params = useParams<{ videoId: string }>()
+  const searchedVideoId = params.videoId
 
   const minTitleLength = 10
   const maxTitleLength = 255

--- a/frontend/components/pages/FavoriteVideoList.tsx
+++ b/frontend/components/pages/FavoriteVideoList.tsx
@@ -103,7 +103,7 @@ export function FavoriteVideoList({ favoriteVideos }: FavoriteVideoListProps) {
                               </Text>
                               <Flex justify="flex-end">
                                 <Link
-                                  href={`/course/${course.id}?videoId=${video.id}`}
+                                  href={`/course/${course.id}/${video.id}`}
                                   mt="2"
                                   color={PRIMARY_FONT_COLOR}
                                   _hover={{ textDecoration: 'none' }}


### PR DESCRIPTION
## 概要
- 動画詳細画面をクエリパラメータからパスパラメータへ修正
- それに伴う、関連リンクの記述の修正

## 変更理由
クエリパラメータの用途である「検索条件の指定」などが当てはまらない箇所でクエリパラメータを使用しているため

## 機能実行結果の動画
https://github.com/ishida-frontend/engineer-tenshoku-master/assets/72023616/2086b5c5-c711-463b-8bf1-35827bbf7a51

## コメント
修正前の URL 例：
/course/c84a5050-5dba-460b-a2e4-00ce03946e35?videoId=dc670114-efc7-4308-85f3-8cbfb4c5372d
修正後の URL 例
/course/c84a5050-5dba-460b-a2e4-00ce03946e35/dc670114-efc7-4308-85f3-8cbfb4c5372d