### PR TITLE
セクション進捗率を未ログイン時は表示しないようにする実装

### DIFF
--- a/frontend/components/organisms/CourseDetailAccordionMenu.tsx
+++ b/frontend/components/organisms/CourseDetailAccordionMenu.tsx
@@ -78,7 +78,7 @@ export function CourseDetailAccordionMenu({
           courseData.sections.map((section, sectionIndex) => {
             const sectionProgress = getSectionCompletionPercentage(
               sectionIndex,
-              session.user.id,
+              session?.user?.id,
             )
             return (
               <AccordionItem key={section.id} borderTopWidth={'1px'}>
@@ -93,9 +93,11 @@ export function CourseDetailAccordionMenu({
                           <Text>{section.title}</Text>
                         </HStack>
                       </Heading>
-                      <Box>
-                        <Text>進捗率{sectionProgress.toFixed(0)}%</Text>
-                      </Box>
+                      {session?.user?.id && (
+                        <Box>
+                          <Text>進捗率{sectionProgress.toFixed(0)}%</Text>
+                        </Box>
+                      )}
                     </Box>
                     <AccordionIcon />
                   </AccordionButton>


### PR DESCRIPTION
## 概要
セクションの進捗率が、ログインしてないとき常に0％と表示されてしまっているのを
ログインしてないときは進捗率表示しないように変更しました

## 実装理由・変更理由
ログインしてないと視聴完了ボタンも表示されず、常にセクション進捗率0％と出てしまうため

## 特にレビューしてもらいたいこと
プルリクの概要欄この書き方で相手に伝わるかどうか
ブランチ名、変な気がするので見て頂きたいです

## 機能実行結果の動画

## 機能実行結果のスクショ
ログインしてないとき
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/4904b512-2e73-4009-8e26-c751b6025cf6)

ログインしているとき
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/77fa96a5-c422-48b1-95ce-40249d3fd7b8)


## UI変更前後のスクショ

## コメント
確認お願いします！