### PR TITLE
TagApplicationServiceテストコード実装

### DIFF
--- a/backend/__tests__/medium/application-services/tag.test.ts
+++ b/backend/__tests__/medium/application-services/tag.test.ts
@@ -36,20 +36,30 @@ beforeEach(() => {
   tagService = new TagApplicationService(prismaMock)
 })
 
-test('タグの新規作成が成功すること', async () => {
-  const expectedTag = createExpectedTag()
+describe('広告の新規作成機能', () => {
+  test('タグの新規作成が成功すること', async () => {
+    const expectedTag = createExpectedTag()
 
-  prismaMock.tag.create.mockResolvedValue(expectedTag)
+    prismaMock.tag.create.mockResolvedValue(expectedTag)
 
-  const createdTag = await tagService.createTag(tagParams)
-  expect(createdTag).toEqual(expectedTag)
-})
+    const createdTag = await tagService.createTag(tagParams)
+    expect(createdTag).toEqual(expectedTag)
+  })
 
-test('タグの新規作成に失敗した際にエラーが投げられること', async () => {
-  const errorMessage = 'タグの新規作成に失敗しました'
-  prismaMock.tag.create.mockRejectedValue(new Error(errorMessage))
+  test('タグの新規作成に失敗した際にエラーが投げられること', async () => {
+    const errorMessage =
+      'TagApplicationService: create tag error: Error: エラーメッセージ'
+    const expectedError = new Error('エラーメッセージ')
+    prismaMock.tag.create.mockRejectedValue(expectedError)
 
-  await expect(tagService.createTag(tagParams)).rejects.toThrow(errorMessage)
+    try {
+      await tagService.createTag(tagParams)
+
+      fail('エラーが投げられませんでした')
+    } catch (error) {
+      expect((error as Error).message).toBe(errorMessage)
+    }
+  })
 })
 
 test('タグの更新が成功すること', async () => {

--- a/backend/__tests__/medium/application-services/tag.test.ts
+++ b/backend/__tests__/medium/application-services/tag.test.ts
@@ -127,14 +127,13 @@ describe('削除されていないタグを全て取得する機能', () => {
     })
   })
 
-  test('削除されていないタグが取得されない場合、エラーが投げられること', async () => {
+  test('タグの取得に失敗した際にエラーが投げられること', async () => {
     const expectedError = 'エラーメッセージ'
     const errorMessage = `TagApplicationService: get tags error: エラーメッセージ`
-    prismaMock.tag.findMany.mockResolvedValue(expectedError)
+
+    prismaMock.tag.findMany.mockRejectedValue(expectedError)
 
     expect.assertions(1)
-    await expect(tagService.getTags()).rejects.toThrow(
-      errorMessage,
-    )
+    await expect(tagService.getTags()).rejects.toThrow(errorMessage)
   })
 })

--- a/backend/__tests__/medium/application-services/tag.test.ts
+++ b/backend/__tests__/medium/application-services/tag.test.ts
@@ -3,19 +3,24 @@ import { TagApplicationService } from '../../../application/tag'
 
 let tagService: TagApplicationService
 
-beforeEach(() => {
-  tagService = new TagApplicationService(prismaMock)
-})
+const tagId = 'tag_id_1'
 
-test('タグの新規作成が成功すること', async () => {
-  const tagParams = {
-    name: 'Node.js',
-    color: 'white',
-    backgroundColor: 'green',
-  }
+const tagParams = {
+  name: 'Node.js',
+  color: 'white',
+  backgroundColor: 'green',
+}
 
-  const expectedTag = {
-    id: expect.any(String),
+const updatedTagParams = {
+  id: tagId,
+  name: 'React.js',
+  color: 'blue',
+  backgroundColor: 'black',
+}
+
+function createExpectedTag(overrides = {}) {
+  return {
+    id: tagId,
     name: 'Node.js',
     color: 'white',
     backgroundColor: 'green',
@@ -23,7 +28,16 @@ test('タグの新規作成が成功すること', async () => {
     updated_at: expect.any(Date),
     deleted_at: null,
     courseId: null,
+    ...overrides,
   }
+}
+
+beforeEach(() => {
+  tagService = new TagApplicationService(prismaMock)
+})
+
+test('タグの新規作成が成功すること', async () => {
+  const expectedTag = createExpectedTag()
 
   prismaMock.tag.create.mockResolvedValue(expectedTag)
 
@@ -32,14 +46,70 @@ test('タグの新規作成が成功すること', async () => {
 })
 
 test('タグの新規作成に失敗した際にエラーが投げられること', async () => {
-  const tagParams = {
-    name: 'Node.js',
-    color: 'white',
-    backgroundColor: 'green',
-  }
-
   const errorMessage = 'タグの新規作成に失敗しました'
   prismaMock.tag.create.mockRejectedValue(new Error(errorMessage))
 
   await expect(tagService.createTag(tagParams)).rejects.toThrow(errorMessage)
+})
+
+test('タグの更新が成功すること', async () => {
+  const expectedUpdatedTag = createExpectedTag({
+    name: updatedTagParams.name,
+    color: updatedTagParams.color,
+    backgroundColor: updatedTagParams.backgroundColor,
+    updated_at: new Date(),
+  })
+
+  prismaMock.tag.update.mockResolvedValue(expectedUpdatedTag)
+
+  const updatedTag = await tagService.updateTag(updatedTagParams)
+  expect(updatedTag).toEqual(expectedUpdatedTag)
+})
+
+test('タグの更新が失敗した際にエラーが投げられること', async () => {
+  const errorMessage = 'タグの更新に失敗しました'
+  prismaMock.tag.update.mockRejectedValue(new Error(errorMessage))
+
+  await expect(tagService.updateTag(updatedTagParams)).rejects.toThrow(
+    errorMessage,
+  )
+})
+
+test('指定されたtagIdのタグが正しく取得されること', async () => {
+  const expectedTag = createExpectedTag()
+
+  prismaMock.tag.findUnique.mockResolvedValue(expectedTag)
+
+  const fetchedTag = await tagService.getTag(tagId)
+  expect(fetchedTag).toEqual(expectedTag)
+})
+
+test('指定されたタグの取得に失敗した際にエラーが投げられること', async () => {
+  const errorMessage = 'タグの取得に失敗しました'
+  prismaMock.tag.findUnique.mockRejectedValue(new Error(errorMessage))
+
+  await expect(tagService.getTag('invalid_tag_id')).rejects.toThrow(
+    errorMessage,
+  )
+})
+
+test('削除されていないタグが取得されること', async () => {
+  const activeTags = [
+    createExpectedTag({ id: 'tag_id_1', name: 'Tag 1', color: 'red' }),
+    createExpectedTag({ id: 'tag_id_2', name: 'Tag 2', color: 'blue' }),
+    createExpectedTag({ id: 'tag_id_3', name: 'Tag 3', color: 'green' }),
+  ]
+
+  prismaMock.tag.findMany.mockResolvedValue(activeTags)
+
+  const fetchedTags = await tagService.getTags()
+  fetchedTags.forEach((tag) => {
+    expect(tag.deleted_at).toBeNull()
+  })
+})
+
+test('削除されていないタグが取得されない場合、エラーが投げられること', async () => {
+  prismaMock.tag.findMany.mockResolvedValue([])
+
+  await expect(tagService.getTags()).resolves.toEqual([])
 })

--- a/backend/__tests__/medium/application-services/tag.test.ts
+++ b/backend/__tests__/medium/application-services/tag.test.ts
@@ -107,25 +107,27 @@ describe('指定されたtagIdのタグを取得する機能', () => {
 })
 
 describe('削除されていないタグを全て取得する機能', () => {
-  test('削除されていないタグが取得されること', async () => {
-    const activeTags = [
-      createExpectedTag({ id: 'tag_id_1', name: 'Tag 1', color: 'red' }),
-      createExpectedTag({ id: 'tag_id_2', name: 'Tag 2', color: 'blue' }),
-      createExpectedTag({
-        id: 'tag_id_3',
-        name: 'Tag 3',
-        color: 'green',
-        deleted_at: new Date(),
-      }),
-    ]
+  // TODO: DBに接続して実際にデータ作って判定する
+  // Notion: https://www.notion.so/tag-DB-8bc308de82354239adf87e3a244ecdcc?pvs=4
+  // test('削除されていないタグが取得されること', async () => {
+  //   const activeTags = [
+  //     createExpectedTag({ id: 'tag_id_1', name: 'Tag 1', color: 'red' }),
+  //     createExpectedTag({ id: 'tag_id_2', name: 'Tag 2', color: 'blue' }),
+  //     createExpectedTag({
+  //       id: 'tag_id_3',
+  //       name: 'Tag 3',
+  //       color: 'green',
+  //       deleted_at: new Date(),
+  //     }),
+  //   ]
 
-    prismaMock.tag.findMany.mockResolvedValue(activeTags)
+  //   prismaMock.tag.findMany.mockResolvedValue(activeTags)
 
-    const fetchedTags = await tagService.getTags()
-    fetchedTags.forEach((tag) => {
-      expect(tag.deleted_at).toBeNull()
-    })
-  })
+  //   const fetchedTags = await tagService.getTags()
+  //   fetchedTags.forEach((tag) => {
+  //     expect(tag.deleted_at).toBeNull()
+  //   })
+  // })
 
   test('タグの取得に失敗した際にエラーが投げられること', async () => {
     const expectedError = 'エラーメッセージ'

--- a/backend/__tests__/medium/application-services/tag.test.ts
+++ b/backend/__tests__/medium/application-services/tag.test.ts
@@ -1,12 +1,10 @@
 import { prismaMock } from '../../singleton'
 import { TagApplicationService } from '../../../application/tag'
-import * as jest_mock_extended_1 from 'jest-mock-extended'
 
 let tagService: TagApplicationService
 
 beforeEach(() => {
   tagService = new TagApplicationService(prismaMock)
-  jest_mock_extended_1.mockReset(prismaMock)
 })
 
 test('タグの新規作成が成功すること', async () => {
@@ -42,7 +40,6 @@ test('タグの新規作成に失敗した際にエラーが投げられるこ�
 
   const errorMessage = 'タグの新規作成に失敗しました'
   prismaMock.tag.create.mockRejectedValue(new Error(errorMessage))
-  console.log("aaaaaaaaaaaaaaa",exports.prismaMock)
 
   await expect(tagService.createTag(tagParams)).rejects.toThrow(errorMessage)
 })

--- a/backend/__tests__/medium/application-services/tag.test.ts
+++ b/backend/__tests__/medium/application-services/tag.test.ts
@@ -47,79 +47,94 @@ describe('広告の新規作成機能', () => {
   })
 
   test('タグの新規作成に失敗した際にエラーが投げられること', async () => {
+    const expectedError = 'エラーメッセージ'
     const errorMessage =
-      'TagApplicationService: create tag error: Error: エラーメッセージ'
-    const expectedError = new Error('エラーメッセージ')
+      'TagApplicationService: create tag error: エラーメッセージ'
     prismaMock.tag.create.mockRejectedValue(expectedError)
 
-    try {
-      await tagService.createTag(tagParams)
-
-      fail('エラーが投げられませんでした')
-    } catch (error) {
-      expect((error as Error).message).toBe(errorMessage)
-    }
+    expect.assertions(1)
+    await expect(tagService.createTag(tagParams)).rejects.toThrow(errorMessage)
   })
 })
 
-test('タグの更新が成功すること', async () => {
-  const expectedUpdatedTag = createExpectedTag({
-    name: updatedTagParams.name,
-    color: updatedTagParams.color,
-    backgroundColor: updatedTagParams.backgroundColor,
-    updated_at: new Date(),
+describe('タグの更新機能', () => {
+  test('タグの更新が成功すること', async () => {
+    const expectedUpdatedTag = createExpectedTag({
+      name: updatedTagParams.name,
+      color: updatedTagParams.color,
+      backgroundColor: updatedTagParams.backgroundColor,
+      updated_at: new Date(),
+    })
+
+    prismaMock.tag.update.mockResolvedValue(expectedUpdatedTag)
+
+    const updatedTag = await tagService.updateTag(updatedTagParams)
+    expect(updatedTag).toEqual(expectedUpdatedTag)
   })
 
-  prismaMock.tag.update.mockResolvedValue(expectedUpdatedTag)
+  test('タグの更新が失敗した際にエラーが投げられること', async () => {
+    const expectedError = 'エラーメッセージ'
+    const errorMessage = `TagApplicationService: update tag error: エラーメッセージ`
+    prismaMock.tag.update.mockRejectedValue(expectedError)
 
-  const updatedTag = await tagService.updateTag(updatedTagParams)
-  expect(updatedTag).toEqual(expectedUpdatedTag)
-})
-
-test('タグの更新が失敗した際にエラーが投げられること', async () => {
-  const errorMessage = 'タグの更新に失敗しました'
-  prismaMock.tag.update.mockRejectedValue(new Error(errorMessage))
-
-  await expect(tagService.updateTag(updatedTagParams)).rejects.toThrow(
-    errorMessage,
-  )
-})
-
-test('指定されたtagIdのタグが正しく取得されること', async () => {
-  const expectedTag = createExpectedTag()
-
-  prismaMock.tag.findUnique.mockResolvedValue(expectedTag)
-
-  const fetchedTag = await tagService.getTag(tagId)
-  expect(fetchedTag).toEqual(expectedTag)
-})
-
-test('指定されたタグの取得に失敗した際にエラーが投げられること', async () => {
-  const errorMessage = 'タグの取得に失敗しました'
-  prismaMock.tag.findUnique.mockRejectedValue(new Error(errorMessage))
-
-  await expect(tagService.getTag('invalid_tag_id')).rejects.toThrow(
-    errorMessage,
-  )
-})
-
-test('削除されていないタグが取得されること', async () => {
-  const activeTags = [
-    createExpectedTag({ id: 'tag_id_1', name: 'Tag 1', color: 'red' }),
-    createExpectedTag({ id: 'tag_id_2', name: 'Tag 2', color: 'blue' }),
-    createExpectedTag({ id: 'tag_id_3', name: 'Tag 3', color: 'green' }),
-  ]
-
-  prismaMock.tag.findMany.mockResolvedValue(activeTags)
-
-  const fetchedTags = await tagService.getTags()
-  fetchedTags.forEach((tag) => {
-    expect(tag.deleted_at).toBeNull()
+    expect.assertions(1)
+    await expect(tagService.updateTag(updatedTagParams)).rejects.toThrow(
+      errorMessage,
+    )
   })
 })
 
-test('削除されていないタグが取得されない場合、エラーが投げられること', async () => {
-  prismaMock.tag.findMany.mockResolvedValue([])
+describe('指定されたtagIdのタグを取得する機能', () => {
+  test('指定されたtagIdのタグが正しく取得されること', async () => {
+    const expectedTag = createExpectedTag()
 
-  await expect(tagService.getTags()).resolves.toEqual([])
+    prismaMock.tag.findUnique.mockResolvedValue(expectedTag)
+
+    const fetchedTag = await tagService.getTag(tagId)
+    expect(fetchedTag).toEqual(expectedTag)
+  })
+
+  test('指定されたタグの取得に失敗した際にエラーが投げられること', async () => {
+    const expectedError = 'エラーメッセージ'
+    const errorMessage = `TagApplicationService: get tag error: エラーメッセージ`
+    prismaMock.tag.findUnique.mockRejectedValue(expectedError)
+
+    expect.assertions(1)
+    await expect(tagService.getTag('invalid_tag_id')).rejects.toThrow(
+      errorMessage,
+    )
+  })
+})
+
+describe('削除されていないタグを全て取得する機能', () => {
+  test('削除されていないタグが取得されること', async () => {
+    const activeTags = [
+      createExpectedTag({ id: 'tag_id_1', name: 'Tag 1', color: 'red' }),
+      createExpectedTag({ id: 'tag_id_2', name: 'Tag 2', color: 'blue' }),
+      createExpectedTag({
+        id: 'tag_id_3',
+        name: 'Tag 3',
+        color: 'green',
+        deleted_at: new Date(),
+      }),
+    ]
+
+    prismaMock.tag.findMany.mockResolvedValue(activeTags)
+
+    const fetchedTags = await tagService.getTags()
+    fetchedTags.forEach((tag) => {
+      expect(tag.deleted_at).toBeNull()
+    })
+  })
+
+  test('削除されていないタグが取得されない場合、エラーが投げられること', async () => {
+    const expectedError = 'エラーメッセージ'
+    const errorMessage = `TagApplicationService: get tags error: エラーメッセージ`
+    prismaMock.tag.findMany.mockResolvedValue(expectedError)
+
+    expect.assertions(1)
+    await expect(tagService.getTags()).rejects.toThrow(
+      errorMessage,
+    )
+  })
 })

--- a/backend/__tests__/medium/application-services/tag.test.ts
+++ b/backend/__tests__/medium/application-services/tag.test.ts
@@ -1,10 +1,12 @@
 import { prismaMock } from '../../singleton'
 import { TagApplicationService } from '../../../application/tag'
+import * as jest_mock_extended_1 from 'jest-mock-extended'
 
 let tagService: TagApplicationService
 
 beforeEach(() => {
   tagService = new TagApplicationService(prismaMock)
+  jest_mock_extended_1.mockReset(prismaMock)
 })
 
 test('タグの新規作成が成功すること', async () => {
@@ -40,6 +42,7 @@ test('タグの新規作成に失敗した際にエラーが投げられるこ�
 
   const errorMessage = 'タグの新規作成に失敗しました'
   prismaMock.tag.create.mockRejectedValue(new Error(errorMessage))
+  console.log("aaaaaaaaaaaaaaa",exports.prismaMock)
 
   await expect(tagService.createTag(tagParams)).rejects.toThrow(errorMessage)
 })

--- a/backend/__tests__/singleton.ts
+++ b/backend/__tests__/singleton.ts
@@ -1,18 +1,14 @@
 import { mockDeep, mockReset, DeepMockProxy } from 'jest-mock-extended'
 
 import prisma, { PrismaClient } from '../utils/prismaClient'
-import { Tag } from '@prisma/client'
 
 jest.mock('../utils/prismaClient', () => ({
   __esModule: true,
-  default: mockDeep<PrismaClient>({
-    tag: mockDeep<Tag>(),
-  }),
+  default: mockDeep<PrismaClient>(),
 }))
 
 beforeEach(() => {
-  mockReset(prisma)
+  mockReset(prismaMock)
 })
 
 export const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>
-export const prismaTagMock = prisma.tag as unknown as DeepMockProxy<Tag>

--- a/backend/__tests__/singleton.ts
+++ b/backend/__tests__/singleton.ts
@@ -1,14 +1,18 @@
 import { mockDeep, mockReset, DeepMockProxy } from 'jest-mock-extended'
 
 import prisma, { PrismaClient } from '../utils/prismaClient'
+import { Tag } from '@prisma/client'
 
 jest.mock('../utils/prismaClient', () => ({
   __esModule: true,
-  default: mockDeep<PrismaClient>(),
+  default: mockDeep<PrismaClient>({
+    tag: mockDeep<Tag>(),
+  }),
 }))
 
 beforeEach(() => {
-  mockReset(prismaMock)
+  mockReset(prisma)
 })
 
 export const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>
+export const prismaTagMock = prisma.tag as unknown as DeepMockProxy<Tag>


### PR DESCRIPTION
## 概要
ふみさんの　[Jest導入＆テストを１つ準備](https://github.com/ishida-frontend/engineer-tenshoku-master/pull/214)　から追記
TagApplicationServiceクラス内全てのメソッドの成功・失敗時のテストの実装

## 実装理由・変更理由
本番リリース前の動作確認

## 特にレビューしてもらいたいこと
コードの可読性意識してオブジェクトまとめてみました。

## 機能実行結果のスクショ
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/5f8f4be2-2f8d-4423-a1ef-ad21a95df30a)



## コメント
`overrides`初めて使ったのですが便利ですね
レビューお願いします