### PR TITLE
新規登録画面のバリデーションエラーメッセージを表示させる

### DIFF
--- a/frontend/app/auth/register/page.tsx
+++ b/frontend/app/auth/register/page.tsx
@@ -42,7 +42,7 @@ export default function Register() {
 
   const toast = useToast()
 
-  const cretateAccount = async (
+  const handleSubmit = async (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
     try {
@@ -217,7 +217,7 @@ export default function Register() {
           colorScheme="teal"
           pl={'26px'}
           isLoading={isSubmitting}
-          onClick={cretateAccount}
+          onClick={handleSubmit}
         >
           <Box mr={'16px'}>
             <LuMail />

--- a/frontend/zod/index.ts
+++ b/frontend/zod/index.ts
@@ -1,1 +1,2 @@
 export * from './advertisement'
+export * from './register'

--- a/frontend/zod/register.ts
+++ b/frontend/zod/register.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
-
-export const signupValidationRules = z.object({
+export const registerSchema = z.object({
   email: z.string().email({
     message: 'メールアドレスの形式で入力してください',
   }),


### PR DESCRIPTION
## 概要

- アカウント新規登録時、バリデーションエラーメッセージをユーザーにも見えるようにする
- password　エラーメッセージでは8文字以上となっているが実際は10文字以上でないと通過できない問題を修正


## 実装理由・変更理由
ユーザー目線で使いやすいwebサイトにするため

## 機能実行結果の動画
使用したパスワード: abcABC1-
ぴったり8文字でも通過

https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/4b8f8136-608d-4bc6-ab13-bc7700fc94d7


バリデーションエラーメッセージ
使用したパスワード: abcdABCD
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/d1f7f60a-e0c2-43f0-93b8-48a2bf5f1eb4)


## 機能実行結果のスクショ
メール届いているか確認
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/0d14e066-bbda-4a99-8f93-d5b88ea7a003)

## コメント
レビューお願いします