### PR TITLE
未登録のメールアドレスでログイン失敗時エラーメッセージを表示

### DIFF
--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -10,6 +10,7 @@ import {
   Input,
   Text,
   VStack,
+  useToast,
 } from '@chakra-ui/react'
 import React, { useEffect, useState } from 'react'
 import { BsGoogle } from 'react-icons/bs'
@@ -27,21 +28,28 @@ export default function Login() {
     password: '',
   })
 
+  const toast = useToast()
+
   const handleSubmit = async (
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
     e.preventDefault()
-    try {
-      await signIn('credentials', {
-        email: formState.email,
-        password: formState.password,
-        redirect: false,
-        callbackUrl: '/',
+
+    const result = await signIn('credentials', {
+      email: formState.email,
+      password: formState.password,
+      redirect: false,
+      callbackUrl: '/',
+    })
+    if (result.error) {
+      toast({
+        title: 'このメールアドレスは登録されていません',
+        status: 'error',
+        position: 'top',
+        duration: 3000,
       })
+    } else {
       router.push('/')
-    } catch (err) {
-      console.log('err', err)
-      throw new Error('エラーが発生しました')
     }
   }
 

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -43,7 +43,7 @@ export default function Login() {
     })
     if (result.error) {
       toast({
-        title: 'このメールアドレスは登録されていません',
+        title: 'このメールアドレスは登録されていないかパスワードが誤っています',
         status: 'error',
         position: 'top',
         duration: 3000,


### PR DESCRIPTION
## 概要
未登録のメールアドレスでログインを試みた場合に、エラーメッセージを表示
ログイン成功時のみコース一覧にリダイレクト

## 実装理由・変更理由
使いやすさ向上のため

## 特にレビューしてもらいたいこと

## 機能実行結果の動画

https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/86050ee9-db43-4027-b4f0-c32bebc71c76

## 機能実行結果のスクショ
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/23cfc1e8-d6cb-4797-9877-483ac44df936)

## コメント
レビューお願いします