### PR TITLE
コース編集画面からセクション管理画面へ移動するボタン追加

### DIFF
--- a/frontend/components/admin/pages/CourseEditor.tsx
+++ b/frontend/components/admin/pages/CourseEditor.tsx
@@ -297,6 +297,9 @@ export function CourseEditor({
           変更を保存
         </Button>
         <CourseRemover />
+        <Link href={`/admin/section/manage/${course.id}`}>
+          <Button width="full">セクション編集</Button>
+        </Link>
       </Stack>
     </Box>
   )


### PR DESCRIPTION
## 概要
コース編集画面からセクション管理画面へ移動するボタン追加

## 実装理由・変更理由
管理者画面操作しやすいように

## 特にレビューしてもらいたいこと

## 機能実行結果の動画
https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/bf60b9c0-2b6b-4e90-81bc-6e8fb407b472

## 機能実行結果のスクショ
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/2152137a-1b8e-4cb3-b15d-1675fb368f71)

## UI変更前後のスクショ
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/a49d7cb9-a552-4a77-9d25-700b8f5be476)

## コメント
レビューお願いします