### PR TITLE
管理者画面 セクション管理からビデオ管理画面に移るボタン追加

### DIFF
--- a/frontend/components/admin/organisms/SectionManage.tsx
+++ b/frontend/components/admin/organisms/SectionManage.tsx
@@ -15,6 +15,8 @@ import {
   useDisclosure,
   FormLabel,
   Switch,
+  Stack,
+  Link,
 } from '@chakra-ui/react'
 import { useCustomToast } from '../../../hooks/useCustomToast'
 import { VideoType } from '../../../types'
@@ -242,15 +244,17 @@ export function SectionManage({
                   セクションを追加
                 </Button>
               </HStack>
-              <VStack>
+              <VStack mb={'8px'}>
                 <Button
-                  mb={'10'}
                   colorScheme="teal"
                   type="submit"
                   onClick={(e) => onSubmit(e)}
                 >
                   保存する
                 </Button>
+                <Link href={`/admin/video/manage/${course_id}`}>
+                  <Button>ビデオ編集</Button>
+                </Link>
               </VStack>
             </FormControl>
           </VStack>

--- a/frontend/components/admin/organisms/SectionManage.tsx
+++ b/frontend/components/admin/organisms/SectionManage.tsx
@@ -15,7 +15,6 @@ import {
   useDisclosure,
   FormLabel,
   Switch,
-  Stack,
   Link,
 } from '@chakra-ui/react'
 import { useCustomToast } from '../../../hooks/useCustomToast'


### PR DESCRIPTION
## 概要
管理者画面セクション管理からビデオ管理画面に移るボタン追加

## 実装理由・変更理由
管理画面使いやすいように

## 特にレビューしてもらいたいこと

## 機能実行結果の動画
https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/42945108-ac21-4bf0-8820-622005396afd

## 機能実行結果のスクショ
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/f14f5f7f-5634-4034-a455-baccf25a7462)

## UI変更前後のスクショ
![image](https://github.com/ishida-frontend/engineer-tenshoku-master/assets/151464878/d160ccc4-00e6-454f-aa53-730ad0a1f807)

## コメント
レビューお願いします
